### PR TITLE
docs: use full path for git clone instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo apt install -y git build-essential cmake libwayland-dev libxkbcommon-dev xo
 2. Clone the repository (ensure the `rc/` folder is sourced by Kakoune)
 
 ```sh
-git clone https://github.com/falbru/kakodemon ~/.config/kak/autoload/
+git clone https://github.com/falbru/kakodemon ~/.config/kak/autoload/kakodemon
 ```
 
 3. Build and install the project

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ git clone https://github.com/falbru/kakodemon ~/.config/kak/autoload/kakodemon
 
 ```sh
 cd ~/.config/kak/autoload/kakodemon
+git submodule update --init
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
With the current `git clone` instructions, the project is cloned as `~/.config/kak/autoload` and not `~/.config/kak/autoload/kakodemon` (at least on my Linux system).

So I believe this is unwanted.