### PR TITLE
fix: add missing kakounesession.cpp to test target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(tests
     ${CMAKE_SOURCE_DIR}/src/domain/modeline.cpp
     ${CMAKE_SOURCE_DIR}/src/domain/ports/font.cpp
     ${CMAKE_SOURCE_DIR}/src/domain/ports/kakouneinterface.cpp
+    ${CMAKE_SOURCE_DIR}/src/domain/ports/kakounesession.cpp
     ${CMAKE_SOURCE_DIR}/src/domain/statusline.cpp
     ${CMAKE_SOURCE_DIR}/src/domain/uioptions.cpp
     ${CMAKE_SOURCE_DIR}/src/domain/utf8string.cpp


### PR DESCRIPTION
The test build was failing with a linker error (`undefined reference to domain::kakouneSessionExists`).

Turns out 474d60d added `kakounesession.cpp` to the main kakod target but forgot to add it to the tests target in `test/CMakeLists.txt`. Added it there too.